### PR TITLE
신고가 배지 로직 개선

### DIFF
--- a/daily.html
+++ b/daily.html
@@ -220,6 +220,14 @@
     margin-bottom: 3px; letter-spacing: 0.3px;
     box-shadow: 0 1px 3px rgba(192,57,43,.25);
   }
+  .deal-right .new-badge {
+    display: inline-block;
+    background: linear-gradient(135deg, #4b8df8 0%, #2d6cdf 100%);
+    color: #fff; font-weight: 800; font-size: 10.5px;
+    padding: 2px 7px; border-radius: 10px;
+    margin-bottom: 3px; letter-spacing: 0.3px;
+    box-shadow: 0 1px 3px rgba(45,108,223,.25);
+  }
 
   /* 페이지네이션 */
   .pager { display: flex; gap: 4px; justify-content: center; margin: 14px 0 4px; flex-wrap: wrap; }
@@ -577,10 +585,13 @@ function renderMaxByGu(container, { title, dateStr, rows }) {
 function renderDealCard(r, idx) {
   const dealPrice = Number(r.DEAL_MONEY_NUM || 0);
   const maxPrice = Number(r.MAX_DEAL_MONEY || 0);
-  const isNewHigh = r.DEAL_BTWEEN != null && Number(r.DEAL_BTWEEN) >= 0;
+  const isCanceled = r.IS_CANCEL === 'Y' || !!r.CANCEL_DATE;
+  const hasBtween = r.DEAL_BTWEEN != null && Number(r.DEAL_BTWEEN) >= 0;
   const dealBtween = Number(r.DEAL_BTWEEN || 0);
-  const prevHigh = isNewHigh ? Math.max(0, dealPrice - dealBtween) : 0;
-  const newHighPct = isNewHigh && prevHigh ? pct(dealBtween, prevHigh) : '-';
+  const prevHigh = hasBtween ? Math.max(0, dealPrice - dealBtween) : 0;
+  const isFirstDeal = hasBtween && prevHigh === 0 && !isCanceled;
+  const isNewHigh = hasBtween && dealBtween > 0 && prevHigh > 0 && !isCanceled;
+  const newHighPct = isNewHigh ? pct(dealBtween, prevHigh) : '-';
   const diff = dealPrice - maxPrice;
   const diffPct = maxPrice ? pct(Math.abs(diff), maxPrice) : '-';
   const age = Number(r.DEAL_YEAR) - Number(r.APART_CREATED_YEAR) + 1;
@@ -607,7 +618,6 @@ function renderDealCard(r, idx) {
   const avgSign = avgDiff < 0 ? '▼' : avgDiff > 0 ? '▲' : '';
   const avgClass = avgDiff < 0 ? 'down' : avgDiff > 0 ? 'up' : '';
 
-  const isCanceled = r.IS_CANCEL === 'Y' || !!r.CANCEL_DATE;
   const cancelLine = isCanceled ? `<div class="cancel-date">취소: ${r.CANCEL_DATE || ''}</div>` : '';
   const dealType = r.DEAL_TYPE && r.DEAL_TYPE.trim() ? r.DEAL_TYPE.trim() : '중개거래';
 
@@ -627,8 +637,11 @@ function renderDealCard(r, idx) {
       <div class="price">${fmt(dealPrice)}<span class="unit">만원</span></div>
       ${isNewHigh ? `
         <div class="new-high-badge">🔥 신고가</div>
-        <div class="ref-line">전고가 <b>${prevHigh ? fmt(prevHigh) : '-'}</b></div>
+        <div class="ref-line">전고가 <b>${fmt(prevHigh)}</b></div>
         <div class="up">▲${fmt(dealBtween)} (${newHighPct}%)</div>
+      ` : isFirstDeal ? `
+        <div class="new-badge">NEW</div>
+        <div class="ref-line">첫 거래</div>
       ` : `
         <div class="ref-line">최고가 <b>${fmt(maxPrice)}</b></div>
         <div class="${diffClass}">${diffSign}${fmt(Math.abs(diff))} (${diffPct}%)</div>

--- a/map.html
+++ b/map.html
@@ -54,6 +54,14 @@
     margin-left: 6px; letter-spacing: 0.3px;
     vertical-align: middle;
   }
+  .deal-item .new-badge {
+    display: inline-block;
+    background: linear-gradient(135deg, #4b8df8 0%, #2d6cdf 100%);
+    color: #fff; font-weight: 800; font-size: 10px;
+    padding: 1px 6px; border-radius: 8px;
+    margin-left: 6px; letter-spacing: 0.3px;
+    vertical-align: middle;
+  }
 
   #map { flex: 1; }
 
@@ -104,6 +112,14 @@
     padding: 2px 7px; border-radius: 10px;
     margin: 4px 0 2px; letter-spacing: 0.3px;
     box-shadow: 0 1px 3px rgba(192,57,43,.25);
+  }
+  .infobox .new-badge {
+    display: inline-block;
+    background: linear-gradient(135deg, #4b8df8 0%, #2d6cdf 100%);
+    color: #fff; font-weight: 800; font-size: 10.5px;
+    padding: 2px 7px; border-radius: 10px;
+    margin: 4px 0 2px; letter-spacing: 0.3px;
+    box-shadow: 0 1px 3px rgba(45,108,223,.25);
   }
 
   .err { padding: 16px; color: #c0392b; background: #fdecea; }
@@ -480,17 +496,21 @@ function rebuildSidebar() {
       item.dataset.type = dealType;
       const dealPrice = Number(deal.DEAL_MONEY_NUM || 0);
       const maxPrice = Number(deal.MAX_DEAL_MONEY || 0);
-      const isNewHigh = deal.DEAL_BTWEEN != null && Number(deal.DEAL_BTWEEN) >= 0;
+      const hasBtween = deal.DEAL_BTWEEN != null && Number(deal.DEAL_BTWEEN) >= 0;
       const dealBtween = Number(deal.DEAL_BTWEEN || 0);
-      const prevHigh = isNewHigh ? Math.max(0, dealPrice - dealBtween) : 0;
-      const newHighPct = isNewHigh && prevHigh ? ((dealBtween/prevHigh)*100).toFixed(1) : '-';
+      const prevHigh = hasBtween ? Math.max(0, dealPrice - dealBtween) : 0;
+      const isFirstDeal = hasBtween && prevHigh === 0 && !isCanceled;
+      const isNewHigh = hasBtween && dealBtween > 0 && prevHigh > 0 && !isCanceled;
+      const newHighPct = isNewHigh ? ((dealBtween/prevHigh)*100).toFixed(1) : '-';
       const diff = dealPrice - maxPrice;
-      const diffPct = maxPrice ? ((diff/maxPrice)*100).toFixed(1) : '-';
+      const diffPct = maxPrice ? ((Math.abs(diff)/maxPrice)*100).toFixed(1) : '-';
       const sign = diff < 0 ? '▼' : diff > 0 ? '▲' : '';
       const cls = diff < 0 ? 'down' : diff > 0 ? 'up' : '';
       const ratioHTML = isNewHigh
         ? `<span class="ratio up">▲${newHighPct}%</span><span class="new-high">🔥 신고가</span>`
-        : `<span class="ratio ${cls}">${sign}${Math.abs(diffPct)}%</span>`;
+        : isFirstDeal
+        ? `<span class="new-badge">NEW</span>`
+        : `<span class="ratio ${cls}">${sign}${diffPct}%</span>`;
       item.innerHTML = `
         <div class="name">${deal.APART_NAME}</div>
         <div class="meta">${deal.CITY||''} ${deal.STATE||''} ${deal.APART_DONG} · ${deal.APART_SIZE}㎡ / ${deal.DEAL_FLOOR}층</div>
@@ -534,19 +554,24 @@ function refresh() {
 function infoboxHTML(deal) {
   const dealPrice = Number(deal.DEAL_MONEY_NUM || 0);
   const maxPrice = Number(deal.MAX_DEAL_MONEY || 0);
-  const isNewHigh = deal.DEAL_BTWEEN != null && Number(deal.DEAL_BTWEEN) >= 0;
+  const isCanceled = deal.IS_CANCEL === 'Y' || !!deal.CANCEL_DATE;
+  const hasBtween = deal.DEAL_BTWEEN != null && Number(deal.DEAL_BTWEEN) >= 0;
   const dealBtween = Number(deal.DEAL_BTWEEN || 0);
-  const prevHigh = isNewHigh ? Math.max(0, dealPrice - dealBtween) : 0;
-  const newHighPct = isNewHigh && prevHigh ? ((dealBtween/prevHigh)*100).toFixed(1) : '-';
+  const prevHigh = hasBtween ? Math.max(0, dealPrice - dealBtween) : 0;
+  const isFirstDeal = hasBtween && prevHigh === 0 && !isCanceled;
+  const isNewHigh = hasBtween && dealBtween > 0 && prevHigh > 0 && !isCanceled;
+  const newHighPct = isNewHigh ? ((dealBtween/prevHigh)*100).toFixed(1) : '-';
   const diff = dealPrice - maxPrice;
-  const diffPct = maxPrice ? ((diff/maxPrice)*100).toFixed(1) : '-';
+  const diffPct = maxPrice ? ((Math.abs(diff)/maxPrice)*100).toFixed(1) : '-';
   const sign = diff < 0 ? '▼' : diff > 0 ? '▲' : '';
   const cls = diff < 0 ? 'down' : diff > 0 ? 'up' : '';
-  const isCanceled = deal.IS_CANCEL === 'Y' || !!deal.CANCEL_DATE;
   const refRow = isNewHigh
     ? `<div class="new-high-badge">🔥 신고가</div>
-       <div class="row">전고가 <b>${prevHigh ? fmt(prevHigh) : '-'}</b> · <span class="up">▲${(dealBtween/10000).toFixed(1)}억 (${newHighPct}%)</span></div>`
-    : `<div class="row">최고가 <b>${fmt(maxPrice)}</b> · <span class="${cls}">${sign}${Math.abs(diff/10000).toFixed(1)}억 (${Math.abs(diffPct)}%)</span></div>`;
+       <div class="row">전고가 <b>${fmt(prevHigh)}</b> · <span class="up">▲${(dealBtween/10000).toFixed(1)}억 (${newHighPct}%)</span></div>`
+    : isFirstDeal
+    ? `<div class="new-badge">NEW</div>
+       <div class="row">첫 거래</div>`
+    : `<div class="row">최고가 <b>${fmt(maxPrice)}</b> · <span class="${cls}">${sign}${(Math.abs(diff)/10000).toFixed(1)}억 (${diffPct}%)</span></div>`;
   return `
     <div class="infobox">
       <div class="ttl">${deal.APART_NAME}${isCanceled ? ' <span style="color:#c0392b">(취소)</span>' : ''}</div>


### PR DESCRIPTION
- 신고가 판정을 DEAL_BTWEEN >= 0 → > 0 으로 변경 (동가 거래 제외)
- 비교 대상 없는 첫 거래는 별도 NEW 배지로 분리 표시
- 취소 거래에는 신고가/NEW 배지 노출 차단
- map.html diffPct 계산을 절대값 기반으로 통일하여 표기 일관화

https://claude.ai/code/session_01XTxgM91mEvnP6azBujTdXD