### PR TITLE
daily/map 페이지에 GA4 측정 스니펫 추가

### DIFF
--- a/daily.html
+++ b/daily.html
@@ -2,6 +2,14 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-X26CHDTPFZ"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-X26CHDTPFZ');
+</script>
 <title>일일 아파트 리포트 - 청라실</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="날짜별 전국 아파트 실거래 일일 리포트. 거래량, 평균가, 최고가, 신고가를 지역별로 확인하세요.">

--- a/map.html
+++ b/map.html
@@ -2,6 +2,14 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-X26CHDTPFZ"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-X26CHDTPFZ');
+</script>
 <title>아파트 거래 지도 - 청라실</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="전국 아파트 실거래를 지도에서 확인하세요. 단지별 거래금액, 신고가, 최고가 대비 정보를 지도로 한눈에 파악할 수 있습니다.">


### PR DESCRIPTION
## Summary
- `daily.html`, `map.html` `<head>` 상단에 `gtag.js` 스니펫 삽입
- 기존 `index.html` / `charts.html`과 동일한 측정 ID `G-X26CHDTPFZ` 사용
- 두 페이지의 page_view·이벤트가 GA4로 수집되도록 함

## Test plan
- [ ] 배포 후 `daily.html` 방문 시 GA4 실시간 보고서에 page_view 기록 확인
- [ ] 배포 후 `map.html` 방문 시 GA4 실시간 보고서에 page_view 기록 확인
- [ ] 콘솔에 gtag 관련 오류 없음 확인

https://claude.ai/code/session_01XTxgM91mEvnP6azBujTdXD

---
_Generated by [Claude Code](https://claude.ai/code/session_01XTxgM91mEvnP6azBujTdXD)_