### PR TITLE
history: 모바일 UI 개선

### DIFF
--- a/history/assets/history.css
+++ b/history/assets/history.css
@@ -64,5 +64,45 @@ footer code { background: var(--surface); padding: 1px 5px; border-radius: 3px; 
 .event[id], .era[id] { scroll-margin-top: 24px; }
 .event.flash { animation: flash 1.2s ease-out; }
 @keyframes flash { 0% { background: rgba(88,166,255,0.25); } 100% { background: transparent; } }
+
+.remote-toggle { position: fixed; bottom: 20px; right: 20px; background: var(--accent); color: #0f1419; border: none; width: 48px; height: 48px; border-radius: 50%; cursor: pointer; z-index: 101; display: none; align-items: center; justify-content: center; box-shadow: 0 4px 16px rgba(0,0,0,0.4); font-size: 20px; font-weight: 700; }
+.remote-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 99; display: none; opacity: 0; transition: opacity 0.2s; }
+.remote-backdrop.show { display: block; opacity: 1; }
+
 @media (max-width: 900px) { .remote { right: 12px; width: 110px; font-size: 10px; } }
-@media (max-width: 640px) { .remote { display: none; } }
+@media (max-width: 640px) {
+  body { padding: 20px 14px 80px; }
+  .container { max-width: 100%; }
+  h1 { font-size: 24px; }
+  .subtitle { font-size: 13px; }
+  header { padding-bottom: 18px; margin-bottom: 22px; }
+  .meta { padding: 12px; gap: 10px; grid-template-columns: 1fr 1fr; font-size: 12px; }
+  .meta-label { font-size: 10px; }
+  .notice { padding: 10px 12px; font-size: 12px; margin: 16px 0 24px; }
+  .legend { padding: 12px; font-size: 12px; margin-bottom: 24px; }
+  .legend-row { gap: 6px 12px; }
+  .timeline { padding-left: 16px; }
+  .event { padding-left: 14px; margin-bottom: 22px; }
+  .event::before { left: -22px; width: 10px; height: 10px; top: 7px; }
+  .title { font-size: 15px; }
+  .desc { font-size: 13.5px; }
+  .sources { font-size: 11.5px; }
+  .sources a { display: inline-block; margin: 2px 8px 2px 0; }
+  .era { font-size: 13px; margin-top: 28px; }
+  footer { margin-top: 40px; font-size: 12px; }
+
+  .remote {
+    display: none;
+    position: fixed; top: auto; bottom: 0; left: 0; right: 0;
+    transform: translateY(100%); transition: transform 0.25s ease-out;
+    width: 100%; max-height: 70vh; font-size: 12px;
+    border-radius: 14px 14px 0 0; padding: 14px 12px calc(14px + env(safe-area-inset-bottom, 0));
+    box-shadow: 0 -8px 32px rgba(0,0,0,0.5);
+  }
+  .remote.show { display: block; transform: translateY(0); }
+  .remote-title { font-size: 11px; padding-bottom: 10px; margin-bottom: 10px; }
+  .remote-era { font-size: 11px; padding: 6px 8px; }
+  .remote-year { padding: 8px 12px; font-size: 13px; }
+  .remote-year:hover { padding-left: 16px; }
+  .remote-toggle { display: flex; }
+}

--- a/history/assets/history.js
+++ b/history/assets/history.js
@@ -72,9 +72,51 @@
     else if (e.key === 'k' && i > 0) { e.preventDefault(); yearLinks[i - 1].click(); }
   });
 
-  const remote = document.getElementById('remote');
-  const toggle = document.getElementById('remoteToggle');
-  if (remote && toggle) {
-    toggle.addEventListener('click', () => remote.classList.toggle('show'));
+  let remote = document.getElementById('remote');
+  if (!remote) {
+    remote = document.querySelector('aside.remote');
+    if (remote && !remote.id) remote.id = 'remote';
   }
+
+  let toggle = document.getElementById('remoteToggle');
+  if (remote && !toggle) {
+    toggle = document.createElement('button');
+    toggle.id = 'remoteToggle';
+    toggle.className = 'remote-toggle';
+    toggle.setAttribute('aria-label', '연도 점프 메뉴');
+    toggle.textContent = '📅';
+    document.body.appendChild(toggle);
+  }
+
+  let backdrop = document.querySelector('.remote-backdrop');
+  if (remote && !backdrop) {
+    backdrop = document.createElement('div');
+    backdrop.className = 'remote-backdrop';
+    document.body.appendChild(backdrop);
+  }
+
+  function openRemote() {
+    if (!remote) return;
+    remote.classList.add('show');
+    if (backdrop) backdrop.classList.add('show');
+  }
+  function closeRemote() {
+    if (!remote) return;
+    remote.classList.remove('show');
+    if (backdrop) backdrop.classList.remove('show');
+  }
+
+  if (toggle) {
+    toggle.addEventListener('click', () => {
+      remote.classList.contains('show') ? closeRemote() : openRemote();
+    });
+  }
+  if (backdrop) backdrop.addEventListener('click', closeRemote);
+
+  yearLinks.forEach(a => a.addEventListener('click', () => {
+    if (window.matchMedia('(max-width: 640px)').matches) closeRemote();
+  }));
+  eraButtons.forEach(btn => btn.addEventListener('click', () => {
+    if (window.matchMedia('(max-width: 640px)').matches) closeRemote();
+  }));
 })();

--- a/history/index.html
+++ b/history/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Keyword History — 인덱스</title>
 <style>
   :root {
@@ -237,8 +238,22 @@
   }
 
   @media (max-width: 640px) {
-    .controls { grid-template-columns: 1fr; }
-    .view-toggle { justify-self: start; }
+    body { padding: 20px 14px; }
+    h1 { font-size: 24px; }
+    .subtitle { font-size: 13px; }
+    header { padding-bottom: 18px; margin-bottom: 22px; }
+    .controls { grid-template-columns: 1fr; gap: 12px; margin-bottom: 18px; }
+    .view-toggle { justify-self: stretch; width: 100%; }
+    .view-toggle button { flex: 1; padding: 11px 12px; }
+    .search-input { padding: 11px 14px 11px 38px; font-size: 15px; }
+    .filters { gap: 6px; margin-bottom: 20px; }
+    .filter-chip { padding: 7px 12px; font-size: 12px; }
+    .grid { grid-template-columns: 1fr; gap: 12px; }
+    .card { padding: 16px; }
+    .card-title { font-size: 16px; }
+    .card-summary { font-size: 13px; }
+    .graph-container { padding: 12px; }
+    svg { height: 480px; }
   }
 </style>
 </head>

--- a/history/인천_청라_7호선_2026-05-16.html
+++ b/history/인천_청라_7호선_2026-05-16.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>인천 청라 7호선 — 시계열 히스토리</title>
 <style>
   :root {

--- a/history/인천_청라_BMW_2026-05-16.html
+++ b/history/인천_청라_BMW_2026-05-16.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>인천 청라 BMW R&D센터 — 시계열 히스토리</title>
 <link rel="stylesheet" href="assets/history.css">
 </head>

--- a/history/인천_청라_GM_2026-05-16.html
+++ b/history/인천_청라_GM_2026-05-16.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>인천 청라 한국GM — 시계열 히스토리</title>
 <link rel="stylesheet" href="assets/history.css">
 </head>

--- a/history/인천_청라_GRT_2026-05-16.html
+++ b/history/인천_청라_GRT_2026-05-16.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>인천 청라 GRT — 시계열 히스토리</title>
 <link rel="stylesheet" href="assets/history.css">
 </head>

--- a/history/인천_청라_G시티_2026-05-16.html
+++ b/history/인천_청라_G시티_2026-05-16.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>인천 청라 G시티 — 시계열 히스토리</title>
 <link rel="stylesheet" href="assets/history.css">
 </head>

--- a/history/인천_청라_IHP_2026-05-16.html
+++ b/history/인천_청라_IHP_2026-05-16.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>인천 청라 IHP 도시첨단산업단지 — 시계열 히스토리</title>
 <link rel="stylesheet" href="assets/history.css">
 </head>

--- a/history/인천_청라_UAM_2026-05-16.html
+++ b/history/인천_청라_UAM_2026-05-16.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>인천 청라 UAM — 시계열 히스토리</title>
 <link rel="stylesheet" href="assets/history.css">
 </head>

--- a/history/인천_청라_국제금융단지_2026-05-16.html
+++ b/history/인천_청라_국제금융단지_2026-05-16.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>인천 청라 국제금융단지 — 시계열 히스토리</title>
 <style>
   :root { --bg: #0f1419; --surface: #1a2027; --surface2: #232b35; --border: #2f3a47; --text: #e6edf3; --muted: #8b949e; --accent: #58a6ff; --s: #f85149; --a: #d29922; --b: #58a6ff; --c: #8b949e; --d: #6e7681; --milestone: #3fb950; --conflict: #db6d28; --gap: #484f58; }
@@ -64,8 +65,21 @@
   .event[id], .era[id] { scroll-margin-top: 24px; }
   .event.flash { animation: flash 1.2s ease-out; }
   @keyframes flash { 0% { background: rgba(88,166,255,0.25); } 100% { background: transparent; } }
+  .remote-toggle { position: fixed; bottom: 20px; right: 20px; background: var(--accent); color: #0f1419; border: none; width: 48px; height: 48px; border-radius: 50%; cursor: pointer; z-index: 101; display: none; align-items: center; justify-content: center; box-shadow: 0 4px 16px rgba(0,0,0,0.4); font-size: 20px; font-weight: 700; }
+  .remote-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 99; display: none; }
+  .remote-backdrop.show { display: block; }
   @media (max-width: 900px) { .remote { right: 12px; width: 110px; font-size: 10px; } }
-  @media (max-width: 640px) { .remote { display: none; } }
+  @media (max-width: 640px) {
+    body { padding: 20px 14px 80px; }
+    h1 { font-size: 24px; }
+    .timeline { padding-left: 16px; }
+    .event { padding-left: 14px; }
+    .event::before { left: -22px; width: 10px; height: 10px; }
+    .remote { display: none; position: fixed; top: auto; bottom: 0; left: 0; right: 0; transform: translateY(0); width: 100%; max-height: 70vh; font-size: 12px; border-radius: 14px 14px 0 0; padding: 14px 12px calc(14px + env(safe-area-inset-bottom, 0)); }
+    .remote.show { display: block; }
+    .remote-year { padding: 8px 12px; font-size: 13px; }
+    .remote-toggle { display: flex; }
+  }
 </style>
 </head>
 <body>

--- a/history/인천_청라_달튼외국인학교_2026-05-16.html
+++ b/history/인천_청라_달튼외국인학교_2026-05-16.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>인천 청라 달튼외국인학교 — 시계열 히스토리</title>
 <link rel="stylesheet" href="assets/history.css">
 </head>

--- a/history/인천_청라_돔야구장_2026-05-16.html
+++ b/history/인천_청라_돔야구장_2026-05-16.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>인천 청라 돔야구장 — 시계열 히스토리</title>
 <link rel="stylesheet" href="assets/history.css">
 </head>

--- a/history/인천_청라_로봇랜드_2026-05-16.html
+++ b/history/인천_청라_로봇랜드_2026-05-16.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>인천 청라 로봇랜드 — 시계열 히스토리</title>
 <link rel="stylesheet" href="assets/history.css">
 </head>

--- a/history/인천_청라_베어즈베스트GC_2026-05-16.html
+++ b/history/인천_청라_베어즈베스트GC_2026-05-16.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>인천 청라 베어즈베스트 골프장 — 시계열 히스토리</title>
 <link rel="stylesheet" href="assets/history.css">
 </head>

--- a/history/인천_청라_서울2호선_2026-05-16.html
+++ b/history/인천_청라_서울2호선_2026-05-16.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>인천 청라 서울 2호선 연장 — 시계열 히스토리</title>
 <style>
   :root {

--- a/history/인천_청라_스타필드_2026-05-16.html
+++ b/history/인천_청라_스타필드_2026-05-16.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>인천 청라 스타필드 — 시계열 히스토리</title>
 <link rel="stylesheet" href="assets/history.css">
 </head>

--- a/history/인천_청라_스트리밍시티_2026-05-16.html
+++ b/history/인천_청라_스트리밍시티_2026-05-16.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>인천 청라 스트리밍시티 — 시계열 히스토리</title>
 <link rel="stylesheet" href="assets/history.css">
 </head>

--- a/history/인천_청라_시티타워_2026-05-16.html
+++ b/history/인천_청라_시티타워_2026-05-16.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>인천 서구 청라 시티타워 — 시계열 히스토리</title>
 <style>
   :root {

--- a/history/인천_청라_아산병원_2026-05-16.html
+++ b/history/인천_청라_아산병원_2026-05-16.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>인천 청라 아산병원 — 시계열 히스토리</title>
 <style>
   :root { --bg: #0f1419; --surface: #1a2027; --surface2: #232b35; --border: #2f3a47; --text: #e6edf3; --muted: #8b949e; --accent: #58a6ff; --s: #f85149; --a: #d29922; --b: #58a6ff; --c: #8b949e; --d: #6e7681; --milestone: #3fb950; --conflict: #db6d28; --gap: #484f58; }
@@ -60,8 +61,21 @@
   .event[id], .era[id] { scroll-margin-top: 24px; }
   .event.flash { animation: flash 1.2s ease-out; }
   @keyframes flash { 0% { background: rgba(88,166,255,0.25); } 100% { background: transparent; } }
+  .remote-toggle { position: fixed; bottom: 20px; right: 20px; background: var(--accent); color: #0f1419; border: none; width: 48px; height: 48px; border-radius: 50%; cursor: pointer; z-index: 101; display: none; align-items: center; justify-content: center; box-shadow: 0 4px 16px rgba(0,0,0,0.4); font-size: 20px; font-weight: 700; }
+  .remote-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 99; display: none; }
+  .remote-backdrop.show { display: block; }
   @media (max-width: 900px) { .remote { right: 12px; width: 110px; font-size: 10px; } }
-  @media (max-width: 640px) { .remote { display: none; } }
+  @media (max-width: 640px) {
+    body { padding: 20px 14px 80px; }
+    h1 { font-size: 24px; }
+    .timeline { padding-left: 16px; }
+    .event { padding-left: 14px; }
+    .event::before { left: -22px; width: 10px; height: 10px; }
+    .remote { display: none; position: fixed; top: auto; bottom: 0; left: 0; right: 0; transform: translateY(0); width: 100%; max-height: 70vh; font-size: 12px; border-radius: 14px 14px 0 0; padding: 14px 12px calc(14px + env(safe-area-inset-bottom, 0)); }
+    .remote.show { display: block; }
+    .remote-year { padding: 8px 12px; font-size: 13px; }
+    .remote-toggle { display: flex; }
+  }
 </style>
 </head>
 <body>

--- a/history/인천_청라_영상문화단지_2026-05-16.html
+++ b/history/인천_청라_영상문화단지_2026-05-16.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>인천 청라 영상문화복합단지 — 시계열 히스토리</title>
 <link rel="stylesheet" href="assets/history.css">
 </head>

--- a/history/인천_청라_청라하늘대교_2026-05-16.html
+++ b/history/인천_청라_청라하늘대교_2026-05-16.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>인천 청라 청라하늘대교(제3연륙교) — 시계열 히스토리</title>
 <link rel="stylesheet" href="assets/history.css">
 </head>

--- a/history/인천_청라_코스트코_2026-05-16.html
+++ b/history/인천_청라_코스트코_2026-05-16.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>인천 청라 코스트코 — 시계열 히스토리</title>
 <link rel="stylesheet" href="assets/history.css">
 </head>

--- a/history/인천_청라_하나금융타운_2026-05-16.html
+++ b/history/인천_청라_하나금융타운_2026-05-16.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>인천 청라 하나금융타운 — 시계열 히스토리</title>
 <link rel="stylesheet" href="assets/history.css">
 </head>

--- a/history/인천_청라_현대모비스수소공장_2026-05-16.html
+++ b/history/인천_청라_현대모비스수소공장_2026-05-16.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>인천 청라 현대모비스 수소공장 — 시계열 히스토리</title>
 <link rel="stylesheet" href="assets/history.css">
 </head>

--- a/history/인천_청라_호수공원커널웨이_2026-05-16.html
+++ b/history/인천_청라_호수공원커널웨이_2026-05-16.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>인천 청라 호수공원·커널웨이 — 시계열 히스토리</title>
 <link rel="stylesheet" href="assets/history.css">
 </head>

--- a/history/인천_청라_화훼단지_2026-05-16.html
+++ b/history/인천_청라_화훼단지_2026-05-16.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>인천 청라 화훼단지 — 시계열 히스토리</title>
 <link rel="stylesheet" href="assets/history.css">
 </head>


### PR DESCRIPTION
- 25개 history HTML 전체에 viewport meta 태그 추가 (모바일에서
  데스크톱 너비로 스케일링되던 핵심 문제 해결)
- assets/history.css: 모바일 토글 버튼 + 슬라이드업 시트 +
  backdrop 스타일 추가, 작은 화면용 타이포·여백·타임라인 조정
- assets/history.js: 토글/backdrop 자동 주입, 모바일에서 연도
  점프 탭 시 시트 자동 닫힘
- index.html: 모바일 카드 1열 그리드, 컨트롤 풀너비, 터치
  타겟 확대
- inline CSS 페이지(국제금융단지·아산병원)에 누락된 모바일
  토글 CSS 보강

https://claude.ai/code/session_01P5YiDRCSHbAhte1mkQatyN